### PR TITLE
Add basic Matrix bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+.env
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Test Task Repository
+
+This repository contains assorted system information and a simple Matrix bot.
+
+## Matrix Bot
+
+See [`matrix_bot`](./matrix_bot) for a starting point to build a Matrix bot
+using Python and the `matrix-nio` library.

--- a/matrix_bot/README.md
+++ b/matrix_bot/README.md
@@ -1,0 +1,20 @@
+# Matrix Bot
+
+This folder contains a simple starting point for a Matrix bot using the
+[`matrix-nio`](https://github.com/poljar/matrix-nio) library. The bot connects
+ to a Matrix homeserver, joins a room and echoes back any text messages.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+2. Set environment variables `MATRIX_HOMESERVER`, `MATRIX_USER`, and
+   `MATRIX_PASSWORD` with your credentials.
+3. Run the bot:
+   ```bash
+   python bot.py
+   ```
+
+The bot will log in, join the specified room, and echo messages.

--- a/matrix_bot/bot.py
+++ b/matrix_bot/bot.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+from nio import AsyncClient, MatrixRoom, RoomMessageText
+
+
+async def main():
+    homeserver = os.environ.get("MATRIX_HOMESERVER")
+    user = os.environ.get("MATRIX_USER")
+    password = os.environ.get("MATRIX_PASSWORD")
+    room_id = os.environ.get("MATRIX_ROOM")
+    if not all([homeserver, user, password, room_id]):
+        raise SystemExit("Missing Matrix configuration environment variables")
+
+    client = AsyncClient(homeserver, user)
+    await client.login(password)
+    await client.join(room_id)
+
+    async def message_cb(room: MatrixRoom, event: RoomMessageText) -> None:
+        if event.sender != client.user:
+            await client.room_send(
+                room.room_id,
+                message_type="m.room.message",
+                content={"msgtype": "m.text", "body": event.body},
+            )
+
+    client.add_event_callback(message_cb, RoomMessageText)
+
+    await client.sync_forever(timeout=30000)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/matrix_bot/requirements.txt
+++ b/matrix_bot/requirements.txt
@@ -1,0 +1,1 @@
+matrix-nio


### PR DESCRIPTION
## Summary
- set up a Python-based Matrix bot
- include dependencies and usage docs
- document repo contents in README

## Testing
- `python -m pip install -r matrix_bot/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449cfb00c48326a984dd73fd7ca7fa