### PR TITLE
Implement Paystack webhook HMAC check

### DIFF
--- a/paystackbot/__init__.py
+++ b/paystackbot/__init__.py
@@ -1,0 +1,16 @@
+import os
+import hmac
+import hashlib
+from fastapi import Request, HTTPException
+
+PAYSTACK_SECRET = os.getenv("PAYSTACK_SECRET", "")
+
+async def paystack_webhook(request: Request):
+    """Handle Paystack webhook verifying signature."""
+    signature = request.headers.get("X-Paystack-Signature")
+    body = await request.body()
+    expected = hmac.new(PAYSTACK_SECRET.encode(), body, hashlib.sha512).hexdigest()
+    if not signature or not hmac.compare_digest(signature, expected):
+        raise HTTPException(status_code=400, detail="Invalid signature")
+    return body
+


### PR DESCRIPTION
## Summary
- add a small `paystackbot` package
- implement `paystack_webhook` that verifies the `X-Paystack-Signature` header using HMAC

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844a238e72483268d02efead4e2466c